### PR TITLE
Fix raylib_namespace.h

### DIFF
--- a/icon_tools.h
+++ b/icon_tools.h
@@ -1,6 +1,6 @@
 /**********************************************************************************************
 *
-*   raylib-extrss * Utilities and Shared Components for Raylib
+*   raylib-extras * Utilities and Shared Components for Raylib
 *
 *   icon_tools.h * Helper for setting up a window icon
 *

--- a/raylib_namespace.h
+++ b/raylib_namespace.h
@@ -6,7 +6,7 @@
 *
 *   LICENSE: MIT
 *
-*   Copyright (c) 2021-2023 Jeffrey Myers, Peter Damianov
+*   Copyright (c) 2021-2023 Jeffery Myers, Peter Damianov
 *
 *   Permission is hereby granted, free of charge, to any person obtaining a copy
 *   of this software and associated documentation files (the "Software"), to deal

--- a/raylib_namespace.h
+++ b/raylib_namespace.h
@@ -2,11 +2,11 @@
 *
 *   raylib-extras-cpp * Utilities and Shared Components for Raylib
 *
-*   raylib-namespace.h * Simple wrapper to put raylib in a namespace to help prevent compile colissions
+*   raylib-namespace.h * Simple wrapper to put raylib in a namespace
 *
 *   LICENSE: MIT
 *
-*   Copyright (c) 2021 Jeffery Myers
+*   Copyright (c) 2021-2023 Jeffrey Myers, Peter Damianov
 *
 *   Permission is hereby granted, free of charge, to any person obtaining a copy
 *   of this software and associated documentation files (the "Software"), to deal
@@ -28,39 +28,59 @@
 *
 **********************************************************************************************/
 
-#include <cmath>
+// raylib includes:
 #include <cstdarg>
 namespace rl
 {
 	#include "raylib.h"
-	#include "raymath.h"
-	#include "rlgl.h"
-	
-	constexpr Color  LightGray = { 200, 200, 200, 255 };
-    constexpr Color  Gray = { 128, 128, 128, 255 };
-    constexpr Color  DarkGray{ 80, 80, 80, 255 };
-    constexpr Color  Yellow{ 253, 249, 0, 255 };
-    constexpr Color  Gold{ 255, 203, 0, 255 };
-    constexpr Color  Orange{ 255, 161, 0, 255 };
-    constexpr Color  Pink{ 255, 109, 194, 255 };
-    constexpr Color  Red{ 230, 41, 55, 255 };
-    constexpr Color  Maroon{ 190, 33, 55, 255 };
-    constexpr Color  Green{ 0, 228, 48, 255 };
-    constexpr Color  Lime{ 0, 158, 47, 255 };
-    constexpr Color  DarkGreen{ 0, 117, 44, 255 };
-    constexpr Color  SkyBlue{ 102, 191, 255, 255 };
-    constexpr Color  Blue{ 0, 121, 241, 255 };
-    constexpr Color  DarkBlue{ 0, 82, 172, 255 };
-    constexpr Color  Purple{ 200, 122, 255, 255 };
-    constexpr Color  Violet{ 135, 60, 190, 255 };
-    constexpr Color  DarkPurple{ 112, 31, 126, 255 };
-    constexpr Color  Beige{ 211, 176, 131, 255 };
-    constexpr Color  Brown{ 127, 106, 79, 255 };
-    constexpr Color  DarkBrown{ 76, 63, 47, 255 };
 
-    constexpr Color  White{ 255, 255, 255, 255 };
-    constexpr Color  Black{ 0, 0, 0, 255 };
-    constexpr Color  Blank{ 0, 0, 0, 0 };
-    constexpr Color  Magenta{ 255, 0, 255, 255 };
-    constexpr Color  RayWhite{ 245, 245, 245, 255 };
+	constexpr Color LightGray { 200, 200, 200, 255 };
+	constexpr Color Gray { 128, 128, 128, 255 };
+	constexpr Color DarkGray { 80, 80, 80, 255 };
+	constexpr Color Yellow { 253, 249, 0, 255 };
+	constexpr Color Gold { 255, 203, 0, 255 };
+	constexpr Color Orange { 255, 161, 0, 255 };
+	constexpr Color Pink { 255, 109, 194, 255 };
+	constexpr Color Red { 230, 41, 55, 255 };
+	constexpr Color Maroon { 190, 33, 55, 255 };
+	constexpr Color Green { 0, 228, 48, 255 };
+	constexpr Color Lime { 0, 158, 47, 255 };
+	constexpr Color DarkGreen { 0, 117, 44, 255 };
+	constexpr Color SkyBlue { 102, 191, 255, 255 };
+	constexpr Color Blue { 0, 121, 241, 255 };
+	constexpr Color DarkBlue { 0, 82, 172, 255 };
+	constexpr Color Purple { 200, 122, 255, 255 };
+	constexpr Color Violet { 135, 60, 190, 255 };
+	constexpr Color DarkPurple { 112, 31, 126, 255 };
+	constexpr Color Beige { 211, 176, 131, 255 };
+	constexpr Color Brown { 127, 106, 79, 255 };
+	constexpr Color DarkBrown { 76, 63, 47, 255 };
+
+	constexpr Color White { 255, 255, 255, 255 };
+	constexpr Color Black { 0, 0, 0, 255 };
+	constexpr Color Blank { 0, 0, 0, 0 };
+	constexpr Color Magenta { 255, 0, 255, 255 };
+	constexpr Color RayWhite { 245, 245, 245, 255 };
+}
+
+
+// raymath includes:
+#include <cmath>
+namespace rm
+{
+	using rl::Vector2;
+	using rl::Vector3;
+	using rl::Quaternion;
+	using rl::Matrix;
+	#include "raymath.h"
+}
+
+// rlgl includes:
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+namespace rlgl
+{
+	using rl::Matrix;
+	#include "rlgl.h"
 }

--- a/raylib_namespace.h
+++ b/raylib_namespace.h
@@ -62,4 +62,32 @@ namespace rl
 	constexpr Color Blank { 0, 0, 0, 0 };
 	constexpr Color Magenta { 255, 0, 255, 255 };
 	constexpr Color RayWhite { 245, 245, 245, 255 };
+
+	#undef LIGHTGRAY
+	#undef GRAY
+	#undef DARKGRAY
+	#undef YELLOW
+	#undef GOLD
+	#undef ORANGE
+	#undef PINK
+	#undef RED
+	#undef MAROON
+	#undef GREEN
+	#undef LIME
+	#undef DARKGREEN
+	#undef SKYBLUE
+	#undef BLUE
+	#undef DARKBLUE
+	#undef PURPLE
+	#undef VIOLET
+	#undef DARKPURPLE
+	#undef BEIGE
+	#undef BROWN
+	#undef DARKBROWN
+
+	#undef WHITE
+	#undef BLACK
+	#undef BLANK
+	#undef MAGENTA
+	#undef RAYWHITE
 }

--- a/raymath_namespace.h
+++ b/raymath_namespace.h
@@ -35,6 +35,7 @@
 // be able to accept an rm::Vector2
 namespace rl
 {
+
 #if !defined(RL_MATRIX_TYPE)
 // Matrix, 4x4 components, column major, OpenGL style, right handed
 typedef struct Matrix {
@@ -45,9 +46,7 @@ typedef struct Matrix {
 } Matrix;
 #define RL_MATRIX_TYPE
 #endif
-}
-namespace rl
-{
+
 #if !defined(RL_VECTOR2_TYPE)
 // Vector2 type
 typedef struct Vector2 {
@@ -94,6 +93,7 @@ typedef struct Matrix {
 } Matrix;
 #define RL_MATRIX_TYPE
 #endif
+
 }
 
 

--- a/raymath_namespace.h
+++ b/raymath_namespace.h
@@ -6,7 +6,7 @@
 *
 *   LICENSE: MIT
 *
-*   Copyright (c) 2021-2023 Jeffrey Myers, Peter Damianov
+*   Copyright (c) 2021-2023 Jeffery Myers, Peter Damianov
 *
 *   Permission is hereby granted, free of charge, to any person obtaining a copy
 *   of this software and associated documentation files (the "Software"), to deal

--- a/raymath_namespace.h
+++ b/raymath_namespace.h
@@ -1,0 +1,109 @@
+/**********************************************************************************************
+*
+*   raylib-extras-cpp * Utilities and Shared Components for Raylib
+*
+*   raymath-namespace.h * Simple wrapper to put raymath in a namespace
+*
+*   LICENSE: MIT
+*
+*   Copyright (c) 2021-2023 Jeffrey Myers, Peter Damianov
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy
+*   of this software and associated documentation files (the "Software"), to deal
+*   in the Software without restriction, including without limitation the rights
+*   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*   copies of the Software, and to permit persons to whom the Software is
+*   furnished to do so, subject to the following conditions:
+*
+*   The above copyright notice and this permission notice shall be included in all
+*   copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*   SOFTWARE.
+*
+**********************************************************************************************/
+#pragma once
+
+// declare the raylib types that raymath needs, if they haven't been declared yet
+// they must be in the rl namespace, in order for the types to be compatible 
+// if they weren't defined like this, a function taking an rl::Vector2 wouldn't
+// be able to accept an rm::Vector2
+namespace rl
+{
+#if !defined(RL_MATRIX_TYPE)
+// Matrix, 4x4 components, column major, OpenGL style, right handed
+typedef struct Matrix {
+    float m0, m4, m8, m12;      // Matrix first row (4 components)
+    float m1, m5, m9, m13;      // Matrix second row (4 components)
+    float m2, m6, m10, m14;     // Matrix third row (4 components)
+    float m3, m7, m11, m15;     // Matrix fourth row (4 components)
+} Matrix;
+#define RL_MATRIX_TYPE
+#endif
+}
+namespace rl
+{
+#if !defined(RL_VECTOR2_TYPE)
+// Vector2 type
+typedef struct Vector2 {
+    float x;
+    float y;
+} Vector2;
+#define RL_VECTOR2_TYPE
+#endif
+
+#if !defined(RL_VECTOR3_TYPE)
+// Vector3 type
+typedef struct Vector3 {
+    float x;
+    float y;
+    float z;
+} Vector3;
+#define RL_VECTOR3_TYPE
+#endif
+
+#if !defined(RL_VECTOR4_TYPE)
+// Vector4 type
+typedef struct Vector4 {
+    float x;
+    float y;
+    float z;
+    float w;
+} Vector4;
+#define RL_VECTOR4_TYPE
+#endif
+
+#if !defined(RL_QUATERNION_TYPE)
+// Quaternion type
+typedef Vector4 Quaternion;
+#define RL_QUATERNION_TYPE
+#endif
+
+#if !defined(RL_MATRIX_TYPE)
+// Matrix type (OpenGL style 4x4 - right handed, column major)
+typedef struct Matrix {
+    float m0, m4, m8, m12;      // Matrix first row (4 components)
+    float m1, m5, m9, m13;      // Matrix second row (4 components)
+    float m2, m6, m10, m14;     // Matrix third row (4 components)
+    float m3, m7, m11, m15;     // Matrix fourth row (4 components)
+} Matrix;
+#define RL_MATRIX_TYPE
+#endif
+}
+
+
+// raymath includes:
+#include <cmath>
+namespace rm
+{
+	using rl::Vector2;
+	using rl::Vector3;
+	using rl::Quaternion;
+	using rl::Matrix;
+	#include "raymath.h"
+}

--- a/rlgl_namespace.h
+++ b/rlgl_namespace.h
@@ -2,7 +2,7 @@
 *
 *   raylib-extras-cpp * Utilities and Shared Components for Raylib
 *
-*   raylib-namespace.h * Simple wrapper to put raylib in a namespace
+*   rlgl-namespace.h * Simple wrapper to put rlgl in a namespace
 *
 *   LICENSE: MIT
 *
@@ -29,37 +29,30 @@
 **********************************************************************************************/
 #pragma once
 
-// raylib includes:
-#include <cstdarg>
+// declare the raylib types that rlgl needs, if they haven't been declared yet
+// they must be in the rl namespace, in order for the types to be compatible 
+// if they weren't defined like this, a function taking an rl::Matrix wouldn't
+// be able to accept an rlgl::Matrix
 namespace rl
 {
-	#include "raylib.h"
+#if !defined(RL_MATRIX_TYPE)
+// Matrix, 4x4 components, column major, OpenGL style, right handed
+typedef struct Matrix {
+    float m0, m4, m8, m12;      // Matrix first row (4 components)
+    float m1, m5, m9, m13;      // Matrix second row (4 components)
+    float m2, m6, m10, m14;     // Matrix third row (4 components)
+    float m3, m7, m11, m15;     // Matrix fourth row (4 components)
+} Matrix;
+#define RL_MATRIX_TYPE
+#endif
+}
 
-	constexpr Color LightGray { 200, 200, 200, 255 };
-	constexpr Color Gray { 128, 128, 128, 255 };
-	constexpr Color DarkGray { 80, 80, 80, 255 };
-	constexpr Color Yellow { 253, 249, 0, 255 };
-	constexpr Color Gold { 255, 203, 0, 255 };
-	constexpr Color Orange { 255, 161, 0, 255 };
-	constexpr Color Pink { 255, 109, 194, 255 };
-	constexpr Color Red { 230, 41, 55, 255 };
-	constexpr Color Maroon { 190, 33, 55, 255 };
-	constexpr Color Green { 0, 228, 48, 255 };
-	constexpr Color Lime { 0, 158, 47, 255 };
-	constexpr Color DarkGreen { 0, 117, 44, 255 };
-	constexpr Color SkyBlue { 102, 191, 255, 255 };
-	constexpr Color Blue { 0, 121, 241, 255 };
-	constexpr Color DarkBlue { 0, 82, 172, 255 };
-	constexpr Color Purple { 200, 122, 255, 255 };
-	constexpr Color Violet { 135, 60, 190, 255 };
-	constexpr Color DarkPurple { 112, 31, 126, 255 };
-	constexpr Color Beige { 211, 176, 131, 255 };
-	constexpr Color Brown { 127, 106, 79, 255 };
-	constexpr Color DarkBrown { 76, 63, 47, 255 };
-
-	constexpr Color White { 255, 255, 255, 255 };
-	constexpr Color Black { 0, 0, 0, 255 };
-	constexpr Color Blank { 0, 0, 0, 0 };
-	constexpr Color Magenta { 255, 0, 255, 255 };
-	constexpr Color RayWhite { 245, 245, 245, 255 };
+// rlgl includes:
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+namespace rlgl
+{
+	using rl::Matrix;
+	#include "rlgl.h"
 }

--- a/rlgl_namespace.h
+++ b/rlgl_namespace.h
@@ -6,7 +6,7 @@
 *
 *   LICENSE: MIT
 *
-*   Copyright (c) 2021-2023 Jeffrey Myers, Peter Damianov
+*   Copyright (c) 2021-2023 Jeffery Myers, Peter Damianov
 *
 *   Permission is hereby granted, free of charge, to any person obtaining a copy
 *   of this software and associated documentation files (the "Software"), to deal

--- a/rlgl_namespace.h
+++ b/rlgl_namespace.h
@@ -35,6 +35,7 @@
 // be able to accept an rlgl::Matrix
 namespace rl
 {
+
 #if !defined(RL_MATRIX_TYPE)
 // Matrix, 4x4 components, column major, OpenGL style, right handed
 typedef struct Matrix {
@@ -45,6 +46,7 @@ typedef struct Matrix {
 } Matrix;
 #define RL_MATRIX_TYPE
 #endif
+
 }
 
 // rlgl includes:


### PR DESCRIPTION
previously, raylib_namespace.h didn't seem to compile
(at least, for me, using gcc on Linux)

things I changed:
raymath is now in its own namespace, rm

added my name to the copyright
removed the part about "prevent compile collisions", because a namespace can't do that, it was misleading